### PR TITLE
Have index.tsv use csv.DictWriter

### DIFF
--- a/bottle_app.py
+++ b/bottle_app.py
@@ -92,7 +92,7 @@ def index_tsf():
                                    (), get_column_names=column_names,asDicts=True)
         writer = csv.DictWriter(f, fieldnames=column_names, delimiter="\t")
         for row in rows:
-            write.write(row)
+            writer.write(row)
         bottle.response.content_type = "text/plain"
         return f.getvalue()
 

--- a/bottle_app.py
+++ b/bottle_app.py
@@ -92,7 +92,7 @@ def index_tsf():
                                    (), get_column_names=column_names,asDicts=True)
         writer = csv.DictWriter(f, fieldnames=column_names, delimiter="\t")
         for row in rows:
-            writer.write(row)
+            writer.writerow(row)
         bottle.response.content_type = "text/plain"
         return f.getvalue()
 

--- a/bottle_app.py
+++ b/bottle_app.py
@@ -9,6 +9,7 @@ https://downloads.digitalcorpora.org/reports
 
 """
 
+import csv
 import json
 import sys
 import io
@@ -88,10 +89,10 @@ def index_tsf():
         column_names = []
         rows = dbfile.DBMySQL.csfr(get_dbreader(),
                                    """SELECT * from downloadable WHERE present=1 ORDER BY s3key""",
-                                   (), get_column_names=column_names,asDicts=False)
-        print("\t".join(column_names), file=f)
+                                   (), get_column_names=column_names,asDicts=True)
+        writer = csv.DictWriter(f, fieldnames=column_names, delimiter="\t")
         for row in rows:
-            print("\t".join([str(v) for v in row]), file=f)
+            write.write(row)
         bottle.response.content_type = "text/plain"
         return f.getvalue()
 

--- a/tests/test_tsv_nulls.py
+++ b/tests/test_tsv_nulls.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+
+# Portions of this file contributed by NIST are governed by the following
+# statement:
+#
+# This software was developed at the National Institute of Standards
+# and Technology by employees of the Federal Government in the course
+# of their official duties. Pursuant to title 17 Section 105 of the
+# United States Code this software is not subject to copyright
+# protection and is in the public domain. NIST assumes no
+# responsibility whatsoever for its use by other parties, and makes
+# no guarantees, expressed or implied, about its quality,
+# reliability, or any other characteristic.
+#
+# We would appreciate acknowledgement if the software is used.
+
+import csv
+import io
+
+
+def _test_sv_nulls(delimiter: str, expected: str) -> None:
+    """
+    Confirm expected content form of TSV output with null records.
+
+    Line separator is \\r\\n because of default dialect of Excel.
+
+    Sample data adapted from:
+    https://docs.python.org/3/library/csv.html#csv.DictWriter
+    """
+    with io.StringIO() as f:
+        fieldnames = ['first_name', 'last_name']
+        writer = csv.DictWriter(f, delimiter=delimiter, fieldnames=fieldnames)
+        writer.writeheader()
+        writer.writerow({'first_name': 'Wonderful', 'last_name': 'Spam'})
+        writer.writerow({'first_name': 'OnlyFirst'})
+        writer.writerow({'first_name': 'ExplicitNullLast', 'last_name': None})
+        writer.writerow({'last_name': 'OnlyLast'})
+        # Next row is also out of dict key order.
+        writer.writerow({'last_name': 'ExplicitNullFirst', 'first_name': None})
+        computed = f.getvalue()
+        assert expected == computed
+
+
+def test_csv_nulls() -> None:
+    expected = "first_name,last_name\r\nWonderful,Spam\r\nOnlyFirst,\r\nExplicitNullLast,\r\n,OnlyLast\r\n,ExplicitNullFirst\r\n"
+    _test_sv_nulls(",", expected)
+
+
+def test_tsv_nulls() -> None:
+    expected = "first_name\tlast_name\r\nWonderful\tSpam\r\nOnlyFirst\t\r\nExplicitNullLast\t\r\n\tOnlyLast\r\n\tExplicitNullFirst\r\n"
+    _test_sv_nulls("\t", expected)


### PR DESCRIPTION
PR 62 added `/index.tsv` as a resource.  It performs a custom TSV construction.  This unfortunately raised an issue with null-value handling.  When feeding the TSV into a Python DictReader, unexpected string values occured, e.g.:

```json
{
    "id": "10804012",
    "s3key": "corpora/dfrws/challenge-2021/1_Skimmer_mSD.zip",
    "modified": "2023-03-19 22:00:10",
    "bytes": "36665139",
    "mtime": "None",
    "tags": "None",
    "etag": "None",
    "sha2_256": "None",
    "sha3_256": "None",
    "present": "1"
}
```

Fields that are `NULL` in the database were being serialized as `str(None)` from Python.

This patch uses Python's `csv.DictWriter` to output fields.  A unit test is also added to sanity-check expected behaviors on explicit null value handling, absent value handling, and dictionary field order.